### PR TITLE
Add gcc-multilib for target bcm2711 (RPi4) build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update &&\
         libssl-dev patch libncurses5 libncurses5-dev zlib1g-dev gawk \
         flex gettext wget unzip xz-utils python python-distutils-extra \
         python3 python3-distutils-extra rsync curl libsnmp-dev liblzma-dev \
-        libpam0g-dev cpio rsync && \
+        libpam0g-dev cpio rsync gcc-multilib && \
     apt-get clean && \
     useradd -m user && \
     echo 'user ALL=NOPASSWD: ALL' > /etc/sudoers.d/user


### PR DESCRIPTION
As discussed in #10, add gcc-multilib package to get rid of error when building v23.05.2 for target bcm2711 (RPi4).

Closes #10 